### PR TITLE
Test runs for all matching programs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,10 @@ scf.csv
 compincome.dta
 p16i6.dta
 rscfp2016.dta
+match_0A_results.csv
+match_0B_results.csv
+match_1A_results.csv
+match_1B_results.csv
+match_1C_results.csv
+match_1D_results.csv
 __pycache__/

--- a/match_0A.py
+++ b/match_0A.py
@@ -32,7 +32,7 @@ SCF = pd.read_csv(os.path.join(CUR_PATH, 'scf.csv'))
 # Get the PUF data aged to 2015
 recs = Records('puf.csv')
 pol = Policy()
-calc = Calculator(policy=pol, records=recs)
+calc = Calculator(policy=pol, records=recs, verbose=False)
 calc.advance_to_year(2015)
 calc.calc_all()
 recvars = ['e00200', 'e02100', 'e00900', 'e02000', 'e00400', 'e00300',
@@ -61,7 +61,7 @@ def Match(puf, scf):
     scf_list = list()
     wt_list = list()
     j = 0
-    count = len(scf)
+    count = len(scf) - 1
     bwt = scf.loc[0, 'wgt2']
     epsilon = 0.001
     # Iterate over PUF observations
@@ -95,3 +95,8 @@ def Match(puf, scf):
 # Call the Match function and save the matchings
 match_res = Match(PUF, SCF)
 match_res.to_csv(os.path.join(CUR_PATH, 'match_0A_results.csv'), index=False)
+
+print('Matching complete')
+print('Length of PUF: ' + str(len(PUF)))
+print('Length of SCF: ' + str(len(SCF)))
+print('Length of Match: ' + str(len(match_res)))

--- a/match_0B.py
+++ b/match_0B.py
@@ -41,7 +41,7 @@ SCF['age_group'] = group_age1
 # Get the PUF data aged to 2015
 recs = Records('puf.csv')
 pol = Policy()
-calc = Calculator(policy=pol, records=recs)
+calc = Calculator(policy=pol, records=recs, verbose=False)
 calc.advance_to_year(2015)
 calc.calc_all()
 recvars = ['e00200', 'e02100', 'e00900', 'e02000', 'e00400', 'e00300',
@@ -85,7 +85,7 @@ def Match(puf, scf):
     scf_list = list()
     wt_list = list()
     j = 0
-    count = len(scf)
+    count = len(scf) - 1
     bwt = scf.loc[0, 'wgt2']
     epsilon = 0.001
     # Iterate over PUF observations
@@ -126,3 +126,8 @@ match_res5 = Match(PUF[PUF['age_group'] == 5], SCF[SCF['age_group'] == 5])
 match_res = pd.concat([match_res0, match_res1, match_res2, match_res3,
                        match_res4, match_res5], axis=0)
 match_res.to_csv(os.path.join(CUR_PATH, 'match_0B_results.csv'), index=False)
+
+print('Matching complete')
+print('Length of PUF: ' + str(len(PUF)))
+print('Length of SCF: ' + str(len(SCF)))
+print('Length of Match: ' + str(len(match_res)))

--- a/match_1A.py
+++ b/match_1A.py
@@ -33,7 +33,7 @@ SCF = pd.read_csv(os.path.join(CUR_PATH, 'scf.csv'))
 # Get the PUF data aged to 2015
 recs = Records('puf.csv')
 pol = Policy()
-calc = Calculator(policy=pol, records=recs)
+calc = Calculator(policy=pol, records=recs, verbose=False)
 calc.advance_to_year(2015)
 calc.calc_all()
 recvars = ['e00200', 'e02100', 'e00900', 'e02000', 'e00400', 'e00300',
@@ -81,3 +81,7 @@ def Match(puf, scf):
 match_res = Match(PUF, SCF)
 match_res.to_csv(os.path.join(CUR_PATH, 'match_1A_results.csv'), index=False)
 
+print('Matching complete')
+print('Length of PUF: ' + str(len(PUF)))
+print('Length of SCF: ' + str(len(SCF)))
+print('Length of Match: ' + str(len(match_res)))

--- a/match_1B.py
+++ b/match_1B.py
@@ -44,7 +44,7 @@ SCF['age_group'] = group_age1
 # Get the PUF data aged to 2015
 recs = Records('puf.csv')
 pol = Policy()
-calc = Calculator(policy=pol, records=recs)
+calc = Calculator(policy=pol, records=recs, verbose=False)
 calc.advance_to_year(2015)
 calc.calc_all()
 recvars = ['e00200', 'e02100', 'e00900', 'e02000', 'e00400', 'e00300',
@@ -71,6 +71,8 @@ def Match(puf, scf):
     results. It returns a dataset of pairings of PUF and SCF records and the
     weight accorded to each.
     """
+    puf = puf.reset_index()
+    scf = scf.reset_index()
     incb = np.array(scf['compincome'])
     puf_list = list()
     scf_list = list()
@@ -108,3 +110,7 @@ match_res = pd.concat([match_res0, match_res1, match_res2, match_res3,
                        match_res4, match_res5], axis=0)
 match_res.to_csv(os.path.join(CUR_PATH, 'match_1B_results.csv'), index=False)
 
+print('Matching complete')
+print('Length of PUF: ' + str(len(PUF)))
+print('Length of SCF: ' + str(len(SCF)))
+print('Length of Match: ' + str(len(match_res)))

--- a/match_1C.py
+++ b/match_1C.py
@@ -37,7 +37,7 @@ SCF = pd.read_csv(os.path.join(CUR_PATH, 'scf.csv'))
 # Get the PUF data aged to 2015
 recs = Records('puf.csv')
 pol = Policy()
-calc = Calculator(policy=pol, records=recs)
+calc = Calculator(policy=pol, records=recs, verbose=False)
 calc.advance_to_year(2015)
 calc.calc_all()
 recvars = ['e00200', 'e02100', 'e00900', 'e02000', 'e00400', 'e00300',
@@ -72,6 +72,9 @@ def Match(puf, scf):
     puf_list = list()
     scf_list = list()
     wt_list = list()
+    # Calculate distance
+    v_age = Variance(scf, 'age')
+    v_inc = Variance(scf, 'compincome')
     # Iterate over PUF observations
     for i in range(len(puf)):
         scf1 = copy.deepcopy(scf)
@@ -79,9 +82,6 @@ def Match(puf, scf):
         awt = puf.loc[i, 's006']
         inca = puf.loc[i, 'compincome']
         agea = puf.loc[i, 'age_head']
-        # Calculate distance
-        v_age = Variance(scf, 'age')
-        v_inc = Variance(scf, 'compincome')
         scf1['dist'] = np.sqrt((ageb - agea)**2 / v_age +
                                ((incb - inca)**2 / v_inc))
         # Grab matched observations
@@ -102,3 +102,7 @@ def Match(puf, scf):
 match_res = Match(PUF, SCF)
 match_res.to_csv(os.path.join(CUR_PATH, 'match_1C_results.csv'), index=False)
 
+print('Matching complete')
+print('Length of PUF: ' + str(len(PUF)))
+print('Length of SCF: ' + str(len(SCF)))
+print('Length of Match: ' + str(len(match_res)))

--- a/match_1D.py
+++ b/match_1D.py
@@ -34,7 +34,7 @@ SCF = pd.read_csv(os.path.join(CUR_PATH, 'scf.csv'))
 # Get the PUF data aged to 2015
 recs = Records('puf.csv')
 pol = Policy()
-calc = Calculator(policy=pol, records=recs)
+calc = Calculator(policy=pol, records=recs, verbose=False)
 calc.advance_to_year(2015)
 calc.calc_all()
 recvars = ['e00200', 'e02100', 'e00900', 'e02000', 'e00400', 'e00300',
@@ -70,6 +70,10 @@ def Match(puf, scf):
     puf_list = list()
     scf_list = list()
     wt_list = list()
+    # Calculate distance
+    v_age = Variance(scf, 'age')
+    v_ainc = Variance(scf, 'activeincome')
+    v_pinc = Variance(scf, 'passiveincome')
     # Iterate over PUF observations
     for i in range(len(puf)):
         scf1 = copy.deepcopy(scf)
@@ -78,10 +82,6 @@ def Match(puf, scf):
         Ainca = puf.loc[i, 'activeincome']
         Pinca = puf.loc[i, 'passiveincome']
         agea = puf.loc[i, 'age_head']
-        # Calculate distance
-        v_age = Variance(scf, 'age')
-        v_ainc = Variance(scf, 'activeincome')
-        v_pinc = Variance(scf, 'passiveincome')
         scf1['dist'] = np.sqrt((ageb - agea)**2 / v_age +
                                ((Aincb - Ainca)**2 / v_ainc) +
                                ((Pincb - Pinca)**2 / v_pinc))
@@ -103,3 +103,7 @@ def Match(puf, scf):
 match_res = Match(PUF, SCF)
 match_res.to_csv(os.path.join(CUR_PATH, 'match_1D_results.csv'), index=False)
 
+print('Matching complete')
+print('Length of PUF: ' + str(len(PUF)))
+print('Length of SCF: ' + str(len(SCF)))
+print('Length of Match: ' + str(len(match_res)))


### PR DESCRIPTION
This executes test runs for all the matching files and removes bugs. 

Issue #6 briefly describes the matching results. The `match_0*` versions are faster, but the methodology is potentially problematic. The `match_1*` versions use the more appropriate minimum distance methods. Minimum distance takes longer and produces much larger match files (problematic) because of the multiple imputation in the SCF resulting in 5 observations per household. 

